### PR TITLE
Escrow event parameters

### DIFF
--- a/truffle/contracts/Load/LoadContract.sol
+++ b/truffle/contracts/Load/LoadContract.sol
@@ -39,11 +39,11 @@ contract LoadContract is Ownable {
     event VaultHash(address indexed msgSender, bytes16 indexed shipmentUuid, string vaultHash);
 
     // Escrow Events
-    event EscrowDeposited(address indexed msgSender, bytes16 indexed shipmentUuid, uint256 amount);
+    event EscrowDeposited(address indexed msgSender, bytes16 indexed shipmentUuid, uint256 amount, uint256 funded);
     event EscrowFunded(address indexed msgSender, bytes16 indexed shipmentUuid, uint256 funded, uint256 contracted);
-    event EscrowReleased(address indexed msgSender, bytes16 indexed shipmentUuid, uint256 amount);
-    event EscrowRefunded(address indexed msgSender, bytes16 indexed shipmentUuid, uint256 amount);
-    event EscrowWithdrawn(address indexed msgSender, bytes16 indexed shipmentUuid, uint256 amount);
+    event EscrowReleased(address indexed msgSender, bytes16 indexed shipmentUuid, uint256 funded);
+    event EscrowRefunded(address indexed msgSender, bytes16 indexed shipmentUuid, uint256 funded);
+    event EscrowWithdrawn(address indexed msgSender, bytes16 indexed shipmentUuid, uint256 funded);
 
     event EscrowCreated(address indexed msgSender, bytes16 indexed shipmentUuid, Escrow.FundingType fundingType,
                         uint256 contractedAmount, uint256 createdAt);

--- a/truffle/contracts/Load/lib/Escrow.sol
+++ b/truffle/contracts/Load/lib/Escrow.sol
@@ -7,11 +7,11 @@ library Escrow {
     using SafeMath for uint256;
     using Escrow for Data;
 
-    event EscrowDeposited(address indexed msgSender, bytes16 indexed shipmentUuid, uint256 amount);
+    event EscrowDeposited(address indexed msgSender, bytes16 indexed shipmentUuid, uint256 amount, uint256 funded);
     event EscrowFunded(address indexed msgSender, bytes16 indexed shipmentUuid, uint256 funded, uint256 contracted);
-    event EscrowReleased(address indexed msgSender, bytes16 indexed shipmentUuid, uint256 amount);
-    event EscrowRefunded(address indexed msgSender, bytes16 indexed shipmentUuid, uint256 amount);
-    event EscrowWithdrawn(address indexed msgSender, bytes16 indexed shipmentUuid, uint256 amount);
+    event EscrowReleased(address indexed msgSender, bytes16 indexed shipmentUuid, uint256 funded);
+    event EscrowRefunded(address indexed msgSender, bytes16 indexed shipmentUuid, uint256 funded);
+    event EscrowWithdrawn(address indexed msgSender, bytes16 indexed shipmentUuid, uint256 funded);
 
     enum FundingType {NO_FUNDING, SHIP, ETHER}
     enum State {NOT_CREATED, CREATED, FUNDED, RELEASED, REFUNDED, WITHDRAWN}
@@ -47,7 +47,7 @@ library Escrow {
 
         self.fundedAmount = self.fundedAmount.add(amount);
 
-        emit EscrowDeposited(msg.sender, _shipmentUuid, amount);
+        emit EscrowDeposited(msg.sender, _shipmentUuid, amount, self.fundedAmount);
 
         if (self.fundedAmount >= self.contractedAmount) {
             self.state = State.FUNDED;

--- a/truffle/test/LoadContract_Escrow.js
+++ b/truffle/test/LoadContract_Escrow.js
@@ -155,7 +155,7 @@ contract('LoadContract with Escrow', async (accounts) => {
 
         let fundTx = await contract.fundEscrowEther(shipmentUuid, {from: SHIPPER, value: web3.toWei(0.5, "ether")});
         await truffleAssert.eventEmitted(fundTx, "EscrowDeposited", ev => {
-            return ev.msgSender === SHIPPER && ev.shipmentUuid === shipmentUuid && ev.amount == web3.toWei(0.5, "ether");
+            return ev.msgSender === SHIPPER && ev.shipmentUuid === shipmentUuid && ev.amount == web3.toWei(0.5, "ether") && ev.funded == web3.toWei(0.5, "ether");
         });
 
         let data = await getShipmentEscrowData(shipmentUuid);
@@ -163,14 +163,14 @@ contract('LoadContract with Escrow', async (accounts) => {
 
         fundTx = await contract.fundEscrowEther(shipmentUuid, {from: SHIPPER, value: web3.toWei(0.49, "ether")});
         await truffleAssert.eventEmitted(fundTx, "EscrowDeposited", ev => {
-            return ev.msgSender === SHIPPER && ev.shipmentUuid === shipmentUuid && ev.amount == web3.toWei(0.49, "ether");
+            return ev.msgSender === SHIPPER && ev.shipmentUuid === shipmentUuid && ev.amount == web3.toWei(0.49, "ether") && ev.funded == web3.toWei(0.99, "ether");
         });
         data = await getShipmentEscrowData(shipmentUuid);
         assert.equal(data.escrow.state, EscrowState.CREATED);
 
         fundTx = await contract.fundEscrowEther(shipmentUuid, {from: SHIPPER, value: web3.toWei(0.01, "ether")});
         await truffleAssert.eventEmitted(fundTx, "EscrowDeposited", ev => {
-            return ev.msgSender === SHIPPER && ev.shipmentUuid === shipmentUuid && ev.amount == web3.toWei(0.01, "ether");
+            return ev.msgSender === SHIPPER && ev.shipmentUuid === shipmentUuid && ev.amount == web3.toWei(0.01, "ether") && ev.funded == web3.toWei(1, "ether");
         });
         await truffleAssert.eventEmitted(fundTx, "EscrowFunded", ev => {
             return ev.msgSender === SHIPPER && ev.shipmentUuid === shipmentUuid && ev.funded == web3.toWei(1, "ether") && ev.contracted == web3.toWei(1, "ether");
@@ -194,7 +194,7 @@ contract('LoadContract with Escrow', async (accounts) => {
 
         let releaseTx = await contract.releaseEscrow(shipmentUuid, {from: MODERATOR});
         await truffleAssert.eventEmitted(releaseTx, "EscrowReleased", ev => {
-            return ev.msgSender === MODERATOR && ev.shipmentUuid === shipmentUuid && ev.amount == web3.toWei(1, "ether");
+            return ev.msgSender === MODERATOR && ev.shipmentUuid === shipmentUuid && ev.funded == web3.toWei(1, "ether");
         });
 
         let data = await getShipmentEscrowData(shipmentUuid);
@@ -218,7 +218,7 @@ contract('LoadContract with Escrow', async (accounts) => {
         let carrierBalance = await web3.eth.getBalance(CARRIER);
         let withdrawTxReceipt = await contract.withdrawEscrow(shipmentUuid, {from: CARRIER});
         await truffleAssert.eventEmitted(withdrawTxReceipt, "EscrowWithdrawn", ev => {
-            return ev.msgSender === CARRIER && ev.shipmentUuid === shipmentUuid && ev.amount == web3.toWei(1, "ether");
+            return ev.msgSender === CARRIER && ev.shipmentUuid === shipmentUuid && ev.funded == web3.toWei(1, "ether");
         });
 
         const withdrawTx = await web3.eth.getTransaction(withdrawTxReceipt.tx);
@@ -240,7 +240,7 @@ contract('LoadContract with Escrow', async (accounts) => {
         let carrierBalance = await web3.eth.getBalance(CARRIER);
         let withdrawTxReceipt = await contract.withdrawEscrow(shipmentUuid, {from: CARRIER});
         await truffleAssert.eventEmitted(withdrawTxReceipt, "EscrowWithdrawn", ev => {
-            return ev.msgSender === CARRIER && ev.shipmentUuid === shipmentUuid && ev.amount == web3.toWei(2, "ether");
+            return ev.msgSender === CARRIER && ev.shipmentUuid === shipmentUuid && ev.funded == web3.toWei(2, "ether");
         });
 
         const withdrawTx = await web3.eth.getTransaction(withdrawTxReceipt.tx);
@@ -262,7 +262,7 @@ contract('LoadContract with Escrow', async (accounts) => {
 
         let refundTx = await contract.refundEscrow(shipmentUuid, {from: MODERATOR});
         await truffleAssert.eventEmitted(refundTx, "EscrowRefunded", ev => {
-            return ev.msgSender === MODERATOR && ev.shipmentUuid === shipmentUuid && ev.amount == web3.toWei(1, "ether");
+            return ev.msgSender === MODERATOR && ev.shipmentUuid === shipmentUuid && ev.funded == web3.toWei(1, "ether");
         });
 
         await truffleAssert.reverts(contract.withdrawEscrow(shipmentUuid, {from: MODERATOR}), "Escrow can only be withdrawn by carrier if released or by shipper if refunded");
@@ -271,7 +271,7 @@ contract('LoadContract with Escrow', async (accounts) => {
         let shipperBalance = await web3.eth.getBalance(SHIPPER);
         let withdrawTxReceipt = await contract.withdrawEscrow(shipmentUuid, {from: SHIPPER});
         await truffleAssert.eventEmitted(withdrawTxReceipt, "EscrowWithdrawn", ev => {
-            return ev.msgSender === SHIPPER && ev.shipmentUuid === shipmentUuid && ev.amount == web3.toWei(1, "ether");
+            return ev.msgSender === SHIPPER && ev.shipmentUuid === shipmentUuid && ev.funded == web3.toWei(1, "ether");
         });
 
         const withdrawTx = await web3.eth.getTransaction(withdrawTxReceipt.tx);
@@ -308,7 +308,7 @@ contract('LoadContract with Escrow', async (accounts) => {
         let shipperBalance = await web3.eth.getBalance(SHIPPER);
         let withdrawTxReceipt = await contract.withdrawEscrow(shipmentUuid, {from: SHIPPER});
         await truffleAssert.eventEmitted(withdrawTxReceipt, "EscrowWithdrawn", ev => {
-            return ev.msgSender === SHIPPER && ev.shipmentUuid === shipmentUuid && ev.amount == web3.toWei(0.5, "ether");
+            return ev.msgSender === SHIPPER && ev.shipmentUuid === shipmentUuid && ev.funded == web3.toWei(0.5, "ether");
         });
 
         const withdrawTx = await web3.eth.getTransaction(withdrawTxReceipt.tx);


### PR DESCRIPTION
`fundedAmount` was not being emitted with the `DepositEscrow` event, which required consumers of this event to do their own addition to infer the value of `fundedAmount` in the contract. It's better to emit `fundedAmount` so that the consumers of the event can be confident in the actual value of this variable in the escrow contract at the time of event emission.

Also, event parameter naming was inconsistent, sometimes using `amount` to refer to "deposited amount" and other times using `amount` to refer to fundedAmount. I have added a change to use `amount` for "deposited amount" and `funded` for "funded amount" across all events.